### PR TITLE
Development

### DIFF
--- a/MiniMapLibrary/Basic/Timer.cs
+++ b/MiniMapLibrary/Basic/Timer.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+#nullable enable
+namespace MiniMapLibrary
+{
+    public class Timer
+    {
+        public float Duration { get; private set; } = 1.0f;
+        public float Value { get; set; }
+        public event Action<object?>? OnFinished;
+        public object? State { get; set; }
+        public bool AutoReset { get; set; }
+        public bool Started { get; set; } = true;
+        public bool Expired => Value <= 0;
+
+        public Timer(float duration, bool autoReset = true)
+        {
+            Duration = duration;
+            this.AutoReset = autoReset;
+        }
+
+        public void Update(float deltaTime)
+        {
+            if (Started)
+            {
+                Value -= deltaTime;
+
+                if (Expired)
+                {
+                    if (AutoReset)
+                    {
+                        Reset();
+                    }
+                    else 
+                    {
+                        Started = false;
+                    }
+
+                    OnFinished?.Invoke(State);
+                }
+            }
+        }
+
+        public void Start() => Started = true;
+
+        public void Reset()
+        {
+            Value = Duration;
+            Started = AutoReset;
+        }
+
+        public override string ToString()
+        {
+            return $"{typeof(Timer).Name} [{Value}/{Duration}s] [{nameof(AutoReset)}: {AutoReset}] [{nameof(Started)}: {Started}] [{nameof(Expired)}: {Expired}]";
+        }
+    }
+}

--- a/MiniMapLibrary/Interactible/InteractableKind.cs
+++ b/MiniMapLibrary/Interactible/InteractableKind.cs
@@ -26,6 +26,9 @@ namespace MiniMapLibrary
         Minion = 1 << 14,
         Player = 1 << 15,
         Item =  1 << 16,
-        All = 0xFFFF
+        Portal = 1 << 17,
+        Totem = 1 << 18,
+        Neutral = 1 << 19,
+        All = int.MaxValue
     }
 }

--- a/MiniMapLibrary/Settings.cs
+++ b/MiniMapLibrary/Settings.cs
@@ -26,6 +26,28 @@ namespace MiniMapLibrary
             public const string Shrine = "Textures/MiscIcons/texShrineIconOutlined";
             public const string Boss = "Textures/MiscIcons/texTeleporterIconOutlined";
             public const string Drone = "Textures/MiscIcons/texDroneIconOutlined";
+            public const string Cross = "Textures/MiscIcons/texCriticallyHurtIcon";
+            public const string Lock = "Textures/MiscIcons/texUnlockIcon";
+            public const string Dice = "Textures/MiscIcons/texRuleMapIsRandom";
+            public const string Cube = "Textures/MiscIcons/texLunarPillarIcon";
+            public const string Wrench = "Textures/MiscIcons/texWIPIcon";
+            public const string Attack = "Textures/MiscIcons/texAttackIcon";
+            public const string Sprint = "Textures/MiscIcons/texSprintIcon";
+            public const string Arrow = "Textures/MiscIcons/texOptionsArrowLeft";
+            public const string Pencil = "Textures/MiscIcons/texEditIcon";
+            public const string Portal = "Textures/MiscIcons/texQuickplay";
+        }
+
+        public static class Colors
+        {
+            public static Color Yellow = new Color(255/255.0f, 219 / 255.0f, 88 / 255.0f);
+            public static Color Purple = new Color(122 / 255.0f, 105 / 255.0f, 244 / 255.0f);
+            public static Color DarkPurple = new Color(76 / 255.0f, 53 / 255.0f, 244 / 255.0f);
+            public static Color Teal = new Color(94 / 255.0f, 178 / 255.0f, 242 / 255.0f);
+            public static Color Pink = new Color(172 / 255.0f, 95 / 255.0f, 243 / 255.0f);
+            public static Color DarkPink = new Color(146 / 255.0f, 39 / 255.0f, 243 / 255.0f);
+            public static Color Orange = new Color(255 / 255.0f, 146 / 255.0f, 0 / 255.0f);
+            public static Color DarkTeal = new Color(94 / 255.0f, 178 / 255.0f, 242 / 255.0f);
         }
 
         public static Dimension2D MinimapSize { get; set; } = new Dimension2D(100, 100);
@@ -38,7 +60,7 @@ namespace MiniMapLibrary
 
         public static Color PlayerIconColor { get; set; } = Color.white;
 
-        public static Color DefaultActiveColor { get; set; } = Color.yellow;
+        public static Color DefaultActiveColor { get; set; } = Colors.Yellow;
 
         public static Color DefaultInactiveColor { get; set; } = Color.grey;
 
@@ -58,13 +80,13 @@ namespace MiniMapLibrary
             static void Add(InteractableKind type, 
                 float width = -1, 
                 float height = -1, 
-                Color ActiveColor = default, 
-                Color InactiveColor = default, 
+                Color activeColor = default, 
+                Color inactiveColor = default, 
                 string description = "",
                 string path = Icons.Default)
             {
-                ActiveColor = ActiveColor == default ? DefaultActiveColor : ActiveColor;
-                InactiveColor = InactiveColor == default ? DefaultInactiveColor : InactiveColor;
+                activeColor = activeColor == default ? DefaultActiveColor : activeColor;
+                inactiveColor = inactiveColor == default ? DefaultInactiveColor : inactiveColor;
 
                 Dimension2D size = DefaultUIElementSize;
 
@@ -75,8 +97,8 @@ namespace MiniMapLibrary
 
                 var setting = new InteractibleSetting()
                 {
-                    ActiveColor = ActiveColor,
-                    InactiveColor = InactiveColor,
+                    ActiveColor = activeColor,
+                    InactiveColor = inactiveColor,
                     Dimensions = size
                 };
 
@@ -86,28 +108,32 @@ namespace MiniMapLibrary
                 InteractibleSettings.Add(type, setting);
             }
 
-            Add(InteractableKind.Chest, 10, 8,
+            Add(InteractableKind.Chest, 8, 6,
                 description: "Chests, Roulette Chests",
                 path: Icons.Chest);
 
-            Add(InteractableKind.Shop, 7, 7,
+            Add(InteractableKind.Shop, 7, 5,
+                activeColor: Colors.Teal,
                 description: "Shops",
                 path: Icons.Chest);
 
             Add(InteractableKind.Equipment, 8, 6,
+                activeColor: Colors.Orange,
                 description: "Equipment Barrels",
                 path: Icons.Chest);
 
             Add(InteractableKind.Printer, 10, 8,
+                activeColor: Colors.Purple,
                 description: "Printers",
                 path: Icons.Chest);
 
-            Add(InteractableKind.Utility,
+            Add(InteractableKind.Utility, 5, 5,
                 description: "Scrappers",
-                path: Icons.LootBag);
+                path: Icons.Wrench);
 
             Add(InteractableKind.LunarPod, 7, 7,
                 description: "Lunar pods (chests)",
+                activeColor: Color.cyan,
                 path: Icons.LootBag);
 
             Add(InteractableKind.Shrine,
@@ -115,12 +141,12 @@ namespace MiniMapLibrary
                 path: Icons.Shrine);
            
             Add(InteractableKind.Teleporter, 15, 15,
-                ActiveColor: Color.white,
-                InactiveColor: Color.green,
+                activeColor: Color.white,
+                inactiveColor: Color.green,
                 description: "Boss teleporters",
                 path: Icons.Boss);
 
-            Add(InteractableKind.Barrel, 5, 5,
+            Add(InteractableKind.Barrel, 3, 3,
                 description: "Barrels",
                 path: Icons.Circle);
 
@@ -128,41 +154,59 @@ namespace MiniMapLibrary
                 description: "Drones",
                 path: Icons.Drone);
 
-            Add(InteractableKind.Special, 7, 7,
+            Add(InteractableKind.Special, 5, 5,
                 description: "Special interactibles such as the landing pod and fans",
                 path: Icons.Default);
 
             Add(InteractableKind.EnemyMonster, 3, 3,
-                ActiveColor: Color.red,
+                activeColor: Color.red,
                 description: "Enemies",
                 path: Icons.Circle);
 
             Add(InteractableKind.EnemyLunar, 3, 3,
-                ActiveColor: Color.red,
+                activeColor: Color.red,
                 description: "Lunar enemies",
                 path: Icons.Circle);
 
-            Add(InteractableKind.EnemyVoid, 3, 3,
-                ActiveColor: Color.magenta,
+            Add(InteractableKind.EnemyVoid, 12, 12,
+                activeColor: Color.magenta,
                 description: "Void touched enemies",
-                path: Icons.Circle);
+                path: Icons.Attack);
 
             Add(InteractableKind.Minion, 3, 3,
-                ActiveColor: Color.green,
+                activeColor: Color.green,
                 description: "Minions",
                 path: Icons.Circle);
 
             Add(InteractableKind.Player, 8, 8,
-                ActiveColor: PlayerIconColor,
-                InactiveColor: PlayerIconColor,
+                activeColor: PlayerIconColor,
+                inactiveColor: PlayerIconColor,
                 description: "Player, including friends",
-                path: Icons.Circle);
+                path: Icons.Sprint);
 
             Add(InteractableKind.Item, 3, 3,
-                ActiveColor: Color.cyan,
-                InactiveColor: Color.cyan,
+                activeColor: Colors.Teal,
+                inactiveColor: Color.cyan,
                 description: "Dropped items and lunar coins",
                 path: Icons.Circle);
+
+            Add(InteractableKind.Portal, 7, 7,
+               activeColor: DefaultActiveColor,
+               inactiveColor: DefaultInactiveColor,
+               description: "Portal markers, or objects that spawn portals when interacted with (excluding newt altar)",
+               path: Icons.Portal);
+
+            Add(InteractableKind.Totem, 7, 7,
+               activeColor: Colors.DarkTeal,
+               inactiveColor: DefaultInactiveColor,
+               description: "Totems, or totem adjacent objects",
+               path: Icons.Cube);
+
+            Add(InteractableKind.Neutral, 4, 4,
+               activeColor: Color.white,
+               inactiveColor: DefaultInactiveColor,
+               description: "Neutral objects or NPCs",
+               path: Icons.Circle);
         }
 
         public static InteractibleSetting GetSetting(InteractableKind type)

--- a/MiniMapLibrary/Sprites/SpriteManager.cs
+++ b/MiniMapLibrary/Sprites/SpriteManager.cs
@@ -12,6 +12,13 @@ namespace MiniMapLibrary
     {
         private readonly Dictionary<string, Sprite> SpriteCache = new Dictionary<string, Sprite>();
 
+        private readonly ILogger logger;
+
+        public SpriteManager(ILogger logger)
+        {
+            this.logger = logger;
+        }
+
         public void Dispose()
         {
             SpriteCache.Clear();
@@ -49,7 +56,15 @@ namespace MiniMapLibrary
             }
             else 
             {
-                throw new MissingComponentException($"MissingTextureException: {Path} does not exist within the streaming assets");
+                loaded = Resources.Load<Sprite>(Settings.Icons.Default);
+
+                if (loaded is null)
+                {
+                    logger.LogError($"Attempted to use default icon for non-existen texture at {Path} but default icon path of {Settings.Icons.Default} also failed to load from the streaming assets path.");
+                    return null;
+                }
+
+                SpriteCache.Add(Path, loaded);
             }
 
             return loaded;

--- a/MiniMapLibrary/Sprites/SpriteManager.cs
+++ b/MiniMapLibrary/Sprites/SpriteManager.cs
@@ -64,6 +64,8 @@ namespace MiniMapLibrary
                     return null;
                 }
 
+                logger.LogWarning($"Attempted to load icon texture at streaming asset path: {Path}, but it was not found, using default [?] instead.");
+
                 SpriteCache.Add(Path, loaded);
             }
 

--- a/MiniMapMod/MiniMapPlugin.cs
+++ b/MiniMapMod/MiniMapPlugin.cs
@@ -12,7 +12,7 @@ using MiniMapLibrary.Scanner;
 
 namespace MiniMapMod
 {
-    [BepInPlugin("MiniMap", "Mini Map Mod", "3.2.1")]
+    [BepInPlugin("MiniMap", "Mini Map Mod", "3.3.0")]
     public class MiniMapPlugin : BaseUnityPlugin
     {
         private ISpriteManager SpriteManager;
@@ -33,6 +33,9 @@ namespace MiniMapMod
 
         private ITrackedObjectScanner[] staticScanners;
         private ITrackedObjectScanner[] dynamicScanners;
+
+        private readonly Timer dynamicScanTimer = new(5.0f);
+        private readonly Timer cooldownTimer = new(2.0f, false) { Value = -1.0f };
 
         public void Awake()
         {
@@ -77,6 +80,9 @@ namespace MiniMapMod
             // this will re-scan when the player uses anything like a chest
             // or the landing pod
             GlobalEventManager.OnInteractionsGlobal += (x, y, z) => ScanScene();
+
+            // update the minimap automatically every N seconds regardless of deaths etc
+            dynamicScanTimer.OnFinished += (x) => ScanScene();
         }
 
         //The Update() method is run on every frame of the game.
@@ -93,6 +99,9 @@ namespace MiniMapMod
                     return;
                 }
             }
+
+            cooldownTimer.Update(Time.deltaTime);
+            dynamicScanTimer.Update(Time.deltaTime);
 
             if (Enable)
             {
@@ -212,6 +221,9 @@ namespace MiniMapMod
             logger.LogDebug($"Destroying {nameof(Minimap)}");
             Minimap.Destroy();
 
+            dynamicScanTimer.Reset();
+            cooldownTimer.Reset();
+
             // mark the scene as scannable again so we scan for chests etc..
             ScannedStaticObjects = false;
         }
@@ -224,6 +236,17 @@ namespace MiniMapMod
             // errors
             try
             {
+                if (cooldownTimer.Started is false)
+                {
+                    cooldownTimer.Start();
+                }else if (cooldownTimer.Expired is false)
+                {
+                    return;
+                }
+
+                cooldownTimer.Reset();
+                cooldownTimer.Start();
+
                 logger.LogDebug("Scanning Scene");
 
                 logger.LogDebug("Clearing dynamically tracked objects");
@@ -291,6 +314,25 @@ namespace MiniMapMod
                 ), TrackedDimensions);
         }
 
+        private ITrackedObjectScanner CreateGenericInteractionScanner()
+        {
+            bool PortalSelector(GenericInteraction interaction) => interaction?.contextToken?.Contains("PORTAL") ?? false;
+
+            bool DefaultSelector(GenericInteraction interaction) => true;
+
+            bool GenericActiveChecker(GenericInteraction interaction) => interaction?.isActiveAndEnabled ?? true;
+
+            GameObject DefaultConverter<T>(T value) where T : MonoBehaviour => value?.gameObject;
+
+            return new MultiKindScanner<GenericInteraction>(false,
+                new MonoBehaviorScanner<GenericInteraction>(logger), new MonoBehaviourSorter<GenericInteraction>(
+                    new ISorter<GenericInteraction>[] {
+                        new DefaultSorter<GenericInteraction>(InteractableKind.Portal, DefaultConverter, PortalSelector, GenericActiveChecker),
+                        new DefaultSorter<GenericInteraction>(InteractableKind.Special, DefaultConverter, DefaultSelector, GenericActiveChecker)
+                    }
+                ), TrackedDimensions);
+        }
+
         private ITrackedObjectScanner CreatePurchaseInteractionScanner()
         {
             bool FanSelector(PurchaseInteraction interaction) => interaction?.contextToken == "FAN_CONTEXT";
@@ -300,6 +342,10 @@ namespace MiniMapMod
             bool ShopSelector(PurchaseInteraction interaction) => interaction?.contextToken?.Contains("TERMINAL") ?? false;
 
             bool EquipmentSelector(PurchaseInteraction interaction) => interaction?.contextToken?.Contains("EQUIP") ?? false;
+
+            bool GoldShoresSelector(PurchaseInteraction interaction) => interaction?.contextToken?.Contains("GOLDSHORE") ?? false;
+
+            bool GoldShoresBeaconSelector(PurchaseInteraction interaction) => interaction?.contextToken?.Contains("TOTEM") ?? false;
 
             bool InteractionActiveChecker(PurchaseInteraction interaction) => interaction?.available ?? true;
 
@@ -312,6 +358,8 @@ namespace MiniMapMod
                         new DefaultSorter<PurchaseInteraction>(InteractableKind.Special, DefaultConverter, FanSelector, InteractionActiveChecker),
                         new DefaultSorter<PurchaseInteraction>(InteractableKind.Shop, DefaultConverter, ShopSelector, InteractionActiveChecker),
                         new DefaultSorter<PurchaseInteraction>(InteractableKind.Equipment, DefaultConverter, EquipmentSelector, InteractionActiveChecker),
+                        new DefaultSorter<PurchaseInteraction>(InteractableKind.Portal, DefaultConverter, GoldShoresSelector, InteractionActiveChecker),
+                        new DefaultSorter<PurchaseInteraction>(InteractableKind.Totem, DefaultConverter, GoldShoresBeaconSelector, GoldShoresSelector),
                     }
                 ), TrackedDimensions);
         }
@@ -354,6 +402,7 @@ namespace MiniMapMod
             staticScanners = new ITrackedObjectScanner[] {
                 CreateChestScanner(DefaultActiveChecker),
                 CreatePurchaseInteractionScanner(),
+                CreateGenericInteractionScanner(),
                 SimpleScanner<RouletteChestController>(InteractableKind.Chest),
                 SimpleScanner<ShrineBloodBehavior>(InteractableKind.Shrine),
                 SimpleScanner<ShrineChanceBehavior>(InteractableKind.Shrine),
@@ -364,7 +413,6 @@ namespace MiniMapMod
                 SimpleScanner<ScrapperController>(InteractableKind.Utility),
                 SimpleScanner<TeleporterInteraction>(InteractableKind.Teleporter, activeChecker: (teleporter) => teleporter.activationState != TeleporterInteraction.ActivationState.Charged),
                 SimpleScanner<SummonMasterBehavior>(InteractableKind.Drone),
-                SimpleScanner<GenericInteraction>(InteractableKind.Special),
                 SimpleScanner<BarrelInteraction>(InteractableKind.Barrel, activeChecker: barrel => !barrel.Networkopened),
             };
         }
@@ -376,6 +424,8 @@ namespace MiniMapMod
             bool EnemyLunarSelector(TeamComponent team) => team?.teamIndex == TeamIndex.Lunar;
 
             bool EnemyVoidSelector(TeamComponent team) => team?.teamIndex == TeamIndex.Void;
+
+            bool NeutralSelector(TeamComponent team) => team?.teamIndex == TeamIndex.Neutral;
 
             bool MinionSelector(TeamComponent team)
             {
@@ -410,6 +460,7 @@ namespace MiniMapMod
                         new DefaultSorter<TeamComponent>(InteractableKind.EnemyVoid, DefaultConverter, EnemyVoidSelector, x => true),
                         new DefaultSorter<TeamComponent>(InteractableKind.Minion, DefaultConverter, MinionSelector, x => true),
                         new DefaultSorter<TeamComponent>(InteractableKind.Player, DefaultConverter, PlayerSelector, x => true),
+                        new DefaultSorter<TeamComponent>(InteractableKind.Neutral, DefaultConverter, NeutralSelector, x => x?.gameObject.activeSelf ?? true),
                     }
                 ), TrackedDimensions);
         }
@@ -426,7 +477,8 @@ namespace MiniMapMod
                     range: TrackedDimensions,
                     converter: x => x.gameObject,
                     activeChecker: x => true
-                )
+                ),
+                CreateGenericInteractionScanner()
             };
         }
 

--- a/MiniMapMod/MiniMapPlugin.cs
+++ b/MiniMapMod/MiniMapPlugin.cs
@@ -12,10 +12,10 @@ using MiniMapLibrary.Scanner;
 
 namespace MiniMapMod
 {
-    [BepInPlugin("MiniMap", "Mini Map Mod", "3.2.0")]
+    [BepInPlugin("MiniMap", "Mini Map Mod", "3.2.1")]
     public class MiniMapPlugin : BaseUnityPlugin
     {
-        private readonly ISpriteManager SpriteManager = new SpriteManager();
+        private ISpriteManager SpriteManager;
 
         private readonly List<ITrackedObject> TrackedObjects = new();
 
@@ -39,6 +39,8 @@ namespace MiniMapMod
             // wrap the bepinex logger with an adapter so 
             // we can pass it to the business layer
             logger = new Log(base.Logger);
+
+            SpriteManager = new SpriteManager(logger);
 
             // create the minimap controller
             Minimap = new(logger);

--- a/README.md
+++ b/README.md
@@ -76,8 +76,18 @@ Huge thanks to these awesome people who assisted in creating awesome features fo
 [Arcafanetiz](https://github.com/Arcafanetiz)
 
 ### Change Log
-Minor 3.2.1
+Major 3.3
+- performance major, limited min time between scans to 2 seconds, previous was unlimited, when in 2hr+ runs auto-enemy killing builds caused constant scene scanning
 - fixed bug where chosing wrong icon path in config would lag and crash game with MissingTextureExceptions thrown by `SpriteManager.GetOrCache`
+- added portals
+- added gold shrine
+- added neutral enemy/items/objects (excluding buttons)
+- changed some default sizes for icons
+- added new icons
+- changed player icon
+- changed Void Enemy icon
+- added pillars and totems
+- changed default colors for icons
 
 Major 3.2
 - Re-implemented entire scanning framework for performance to allow more dynamic types at runtime

--- a/README.md
+++ b/README.md
@@ -76,14 +76,19 @@ Huge thanks to these awesome people who assisted in creating awesome features fo
 [Arcafanetiz](https://github.com/Arcafanetiz)
 
 ### Change Log
+Minor 3.2.1
+- fixed bug where chosing wrong icon path in config would lag and crash game with MissingTextureExceptions thrown by `SpriteManager.GetOrCache`
+
 Major 3.2
-- Re-implemented scanning framework for performance
+- Re-implemented entire scanning framework for performance to allow more dynamic types at runtime
 - Added Equipment Barrels
 - Added Shops
 - Added Void Enemies
+- Added Lunar Enemies
 - Added Players (non-client)
 - Added Allies (drones that have been bought)
 - Added Dropped Items / Lunar Coins
+- Fixed bug where the no meaningful stacktrace was being outputted to the log for user debugging
 
 Hotfix 3.1.6
 - fixed typo causing all objects on map being selected to be placed on minimap regardless if they were filtered out

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 ﻿{
   "name": "MiniMapMod",
-  "version_number": "3.2.1",
+  "version_number": "3.3",
   "website_url": "https://github.com/DekuDesu",
-  "description": "Adds a MiniMap to your game v3.2",
+  "description": "Adds a MiniMap to your game v3.3",
   "dependencies": [
     "bbepis-BepInExPack-5.4.9",
     "RiskofThunder-HookGenPatcher-1.2.1"

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "MiniMapMod",
-  "version_number": "3.2.0",
+  "version_number": "3.2.1",
   "website_url": "https://github.com/DekuDesu",
   "description": "Adds a MiniMap to your game v3.2",
   "dependencies": [


### PR DESCRIPTION
- performance major, limited min time between scans to 2 seconds, previous was unlimited, when in 2hr+ runs auto-enemy killing builds caused constant scene scanning
- fixed bug where chosing wrong icon path in config would lag and crash game with MissingTextureExceptions thrown by `SpriteManager.GetOrCache`
- added portals
- added gold shrine
- added neutral enemy/items/objects (excluding buttons)
- changed some default sizes for icons
- added new icons
- changed player icon
- changed Void Enemy icon
- added pillars and totems
- changed default colors for icons