### PR TITLE
Fixed sprites loading

### DIFF
--- a/MiniMapLibrary/MiniMapLibrary.csproj
+++ b/MiniMapLibrary/MiniMapLibrary.csproj
@@ -17,6 +17,9 @@
 		<Reference Include="UnityEngine.UIModule">
 		  <HintPath>..\MiniMapMod\libs\UnityEngine.UIModule.dll</HintPath>
 		</Reference>
+		<Reference Include="LegacyResourcesAPI">
+		  <HintPath>..\MiniMapMod\libs\LegacyResourcesAPI.dll</HintPath>
+		</Reference>
 	</ItemGroup>
 
 </Project>

--- a/MiniMapLibrary/Sprites/SpriteManager.cs
+++ b/MiniMapLibrary/Sprites/SpriteManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
+using RoR2;
 
 #nullable enable
 namespace MiniMapLibrary
@@ -48,7 +49,7 @@ namespace MiniMapLibrary
                 return SpriteCache[Path];
             }
 
-            Sprite? loaded = Resources.Load<Sprite>(Path);
+            Sprite? loaded = RoR2.LegacyResourcesAPI.Load<Sprite>(Path);
 
             if (loaded != null)
             {
@@ -56,7 +57,7 @@ namespace MiniMapLibrary
             }
             else 
             {
-                loaded = Resources.Load<Sprite>(Settings.Icons.Default);
+                loaded = RoR2.LegacyResourcesAPI.Load<Sprite>(Settings.Icons.Default);
 
                 if (loaded is null)
                 {


### PR DESCRIPTION
Currently minimap has a lot of rectangles instead of icons due to some changes in RoR2 assets. This brings icons back.